### PR TITLE
Add support for vertical and horizontal only joysticks

### DIFF
--- a/QMLVirtualJoystick.pro
+++ b/QMLVirtualJoystick.pro
@@ -4,9 +4,7 @@
 #
 #-------------------------------------------------
 
-QT += core gui quick
-
-greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+QT += core gui quick widgets
 
 TARGET = QMLVirtualJoystick
 TEMPLATE = app

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -12,9 +12,19 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
+    addJoyStick(ui->gridLayoutXY);
+    addJoyStick(ui->gridLayoutHorizontal, HorizontalOnly);
+    addJoyStick(ui->gridLayoutVertical, VerticalOnly);
+}
 
+MainWindow::~MainWindow()
+{
+    delete ui;
+}
+
+void MainWindow::addJoyStick(QLayout *layout_, JoyType type)
+{
     QQuickView *view = new QQuickView();
-
     /* NB: We load the QML from a .qrc file becuase the Qt build step
      * that packages the final .app on Mac forgets to add the QML
      * if you reference it directly
@@ -30,7 +40,11 @@ MainWindow::MainWindow(QWidget *parent) :
 #endif
 
     // Attach to the 'mouse moved' signal
-    QQuickItem *root = view->rootObject();
+    auto *root = view->rootObject();
+    if (type == HorizontalOnly)
+        root->setProperty("horizontalOnly", true);
+    else if (type == VerticalOnly)
+        root->setProperty("verticalOnly", true);
     connect(
         root,
         SIGNAL(joystick_moved(double, double)),
@@ -43,12 +57,7 @@ MainWindow::MainWindow(QWidget *parent) :
     container->setMinimumSize(160, 160);
     container->setMaximumSize(160, 160);
     container->setFocusPolicy(Qt::TabFocus);
-    ui->gridLayout->addWidget(container);
-}
-
-MainWindow::~MainWindow()
-{
-    delete ui;
+    layout_->addWidget(container);
 }
 
 /**

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -2,6 +2,7 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QQuickView>
 
 namespace Ui {
 class MainWindow;
@@ -12,8 +13,14 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
+    enum JoyType {
+        XY,
+        HorizontalOnly,
+        VerticalOnly
+    };
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
+    void addJoyStick(QLayout *layout_, JoyType type = XY);
 
 private slots:
     void joystick_moved(double x, double y);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -6,25 +6,40 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>180</width>
-    <height>180</height>
+    <width>452</width>
+    <height>265</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>QML Virtual Joystick Example</string>
   </property>
   <widget class="QWidget" name="centralWidget">
-   <widget class="QWidget" name="gridLayoutWidget">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>10</y>
-      <width>161</width>
-      <height>161</height>
-     </rect>
-    </property>
-    <layout class="QGridLayout" name="gridLayout"/>
-   </widget>
+   <layout class="QGridLayout" name="gridLayout_2">
+    <item row="0" column="1">
+     <widget class="QGroupBox" name="groupBoxXY">
+      <property name="title">
+       <string>X-Y</string>
+      </property>
+      <layout class="QGridLayout" name="gridLayoutXY"/>
+     </widget>
+    </item>
+    <item row="0" column="2">
+     <widget class="QGroupBox" name="groupBoxVertical">
+      <property name="title">
+       <string>Vertical</string>
+      </property>
+      <layout class="QGridLayout" name="gridLayoutVertical"/>
+     </widget>
+    </item>
+    <item row="0" column="3">
+     <widget class="QGroupBox" name="groupBoxHorizontal">
+      <property name="title">
+       <string>Horizontal</string>
+      </property>
+      <layout class="QGridLayout" name="gridLayoutHorizontal"/>
+     </widget>
+    </item>
+   </layout>
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>

--- a/virtual_joystick.qml
+++ b/virtual_joystick.qml
@@ -5,11 +5,15 @@ Rectangle {
     width: joystick.width
     height: joystick.height
     color: "transparent"
+    property bool verticalOnly : false
+    property bool horizontalOnly : false
+
 
     signal joystick_moved(double x, double y);
 
     Image {
         id: joystick
+
 
         property real angle : 0
         property real distance : 0
@@ -27,16 +31,18 @@ Rectangle {
 
         MouseArea {
             id: mouse
-            property real fingerAngle : Math.atan2(mouseX, mouseY)
-            property int mcx : mouseX - width * 0.5
-            property int mcy : mouseY - height * 0.5
+            property real mouseX2 : verticalOnly ? width * 0.5 : mouseX
+            property real mouseY2 : horizontalOnly ? height * 0.5 : mouseY
+            property real fingerAngle : Math.atan2(mouseX2, mouseY2)
+            property int mcx : mouseX2 - width * 0.5
+            property int mcy : mouseY2 - height * 0.5
             property bool fingerInBounds : fingerDistance2 < distanceBound2
             property real fingerDistance2 : mcx * mcx + mcy * mcy
             property real distanceBound : width * 0.5 - thumb.width * 0.5
             property real distanceBound2 : distanceBound * distanceBound
 
-            property double signal_x : (mouseX - joystick.width/2) / distanceBound
-            property double signal_y : -(mouseY - joystick.height/2) / distanceBound
+            property double signal_x : (mouseX2 - joystick.width/2) / distanceBound
+            property double signal_y : -(mouseY2 - joystick.height/2) / distanceBound
 
             anchors.fill: parent
 
@@ -64,13 +70,13 @@ Rectangle {
 
                 if(fingerInBounds) {
                     joystick_moved(
-                        Math.cos(angle) * Math.sqrt(fingerDistance2) / distanceBound,
-                        Math.sin(angle) * Math.sqrt(fingerDistance2) / distanceBound
+                        verticalOnly ? 0 : Math.cos(angle) * Math.sqrt(fingerDistance2) / distanceBound,
+                        horizontalOnly ? 0 : Math.sin(angle) * Math.sqrt(fingerDistance2) / distanceBound
                     );
                 } else {
                     joystick_moved(
-                        Math.cos(angle) * 1,
-                        Math.sin(angle) * 1
+                        verticalOnly ? 0 : Math.cos(angle) * 1,
+                        horizontalOnly ? 0 : Math.sin(angle) * 1
                     );
                 }
             }


### PR DESCRIPTION
Hello @aaronsnoswell 

Many thanks for your work on this component!
I needed to limit the joystick for specific axes (X/Y).

I have added some properties to limit this behavior, and also added this feature to the example code:
![kép](https://user-images.githubusercontent.com/1609182/111843366-5640ec00-8901-11eb-914f-e854d8a77ed1.png)
